### PR TITLE
A few bug fixes

### DIFF
--- a/example/simple.js
+++ b/example/simple.js
@@ -19,5 +19,5 @@ const simpleDecoder = new AC3SimpleDecoder(inputStream);
 
 // Write PCM data to output stream (data is a Uint8Array)
 simpleDecoder.on('data', (data) => {
-    outputStream.push(data);
+    outputStream.write(data);
 });

--- a/src/audioblock.js
+++ b/src/audioblock.js
@@ -66,6 +66,10 @@ export const readAudioBlock = (stream, bsi, samples, imdct, audblk, blk) => {
                 audblk.cplbndstrc[bnd] = stream.read(1);
                 audblk.ncplbnd -= audblk.cplbndstrc[bnd];
             }
+        } else {
+            for (let ch = 0; ch < bsi.nfchans; ch++) {
+                audblk.chincpl[ch] = 0;
+            }
         }
     }
 

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -9,6 +9,8 @@ import {downmix} from './downmix';
 export class AC3Decoder extends Decoder {
     packets = 0;
     pcm = false;
+    samples = null;
+    imdct = null;
 
     constructor(demuxer, format, pcm = false) {
         super(demuxer, format);
@@ -32,21 +34,29 @@ export class AC3Decoder extends Decoder {
         }
 
         // Intialize arrays
-        const samples = new Array(bsi.nfchans);
-        const imdct = new Array(bsi.nfchans);
-        for (let i = 0; i < bsi.nfchans; i++) {
-            samples[i] = new Array(AUDIO_SAMPLES);
-            imdct[i] = new IMDCT();
+        // IMDCT instances must be preserved across chunks for proper decoding.
+        // Otherwise, overlapping samples will be lost.
+        if (!this.samples) {
+            this.samples = new Array(bsi.nfchans);
+            for (let i = 0; i < bsi.nfchans; i++) {
+                this.samples[i] = new Array(AUDIO_SAMPLES);
+            }
+        }
+        if (!this.imdct) {
+            this.imdct = new Array(bsi.nfchans);
+            for (let i = 0; i < bsi.nfchans; i++) {
+                this.imdct[i] = new IMDCT();
+            }
         }
 
         // Audio Blocks
         const audblk = createAudioBlock(bsi);
         for (let blk = 0; blk < 6; blk++) {
-            readAudioBlock(this.bitstream, bsi, samples, imdct, audblk, blk);
+            readAudioBlock(this.bitstream, bsi, this.samples, this.imdct, audblk, blk);
         }
 
         // Downmixing
-        downmix(bsi, samples);
+        downmix(bsi, this.samples);
 
         // Skip auxiliary data
         this.bitstream.align();
@@ -57,11 +67,11 @@ export class AC3Decoder extends Decoder {
             const sampleBytes = new Uint8Array(AUDIO_SAMPLES * CHANNELS * 2);
             let sample;
             for (let i = 0; i < AUDIO_SAMPLES; i++) {
-                sample = samples[0][i] * 65535;
+                sample = this.samples[0][i] * 65535;
                 sampleBytes[i * 4] = sample & 0xff;
                 sampleBytes[i * 4 + 1] = sample >> 8;
 
-                sample = samples[1][i] * 65535;
+                sample = this.samples[1][i] * 65535;
                 sampleBytes[i * 4 + 2] = sample & 0xff;
                 sampleBytes[i * 4 + 3] = sample >> 8;
             }
@@ -73,7 +83,7 @@ export class AC3Decoder extends Decoder {
             let sample;
             for (let i = 0; i < AUDIO_SAMPLES; i++) {
                 for (let ch = 0; ch < CHANNELS; ch++) {
-                    sample = samples[ch][i] * 65535;
+                    sample = this.samples[ch][i] * 65535;
                     result[ch + i * 2] = sample;
                 }
             }


### PR DESCRIPTION
This PR fixes a few bugs:

1) example/simple.js didn't work because push() was called on outputStream instead of write(). This method doesn't exist and caused exceptions to be thrown, which were silently caught.

2) Audio was choppy because IMDCT instances weren't preserved between processing chunks. This resets the overlapping sample window.

3) If channel coupling was previously used in a frame, but then subsequently disabled, chincpl flags weren't being cleared, causing bitstream parsing errors. This was commonly seen on 2/0 test streams.